### PR TITLE
Better method to get the project name

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "eslint": "^5.16.0",
+    "execa": "^1.0.0",
     "history": "4.9.0",
     "ink": "^2.1.1",
     "ink-box": "^1.0.0",
@@ -48,6 +49,10 @@
     "rimraf": "^2.6.3"
   },
   "jest": {
-    "testPathIgnorePatterns": ["/node_modules/", "dist", "scripts"]
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "dist",
+      "scripts"
+    ]
   }
 }

--- a/packages/cli/src/commands/get-project-name.js
+++ b/packages/cli/src/commands/get-project-name.js
@@ -1,9 +1,74 @@
-import { resolve } from 'path';
+import { basename, extname } from 'path';
+import execa from 'execa';
+import path from 'path';
+import meow from 'meow';
 
-const getProjectName = (projectRoot = process.cwd()) => {
-    const packageJson = require(resolve(projectRoot, 'package.json'));
+const defaultCliParams = meow({
+    flags: {
+        project: {
+            type: 'string',
+        },
+    },
+});
 
-    return packageJson.name;
+const defaultCurrentPath = process.cwd();
+
+const defaultParams = {
+    currentPath: defaultCurrentPath,
+    cliParams: defaultCliParams,
+};
+
+/*
+ * If user has specified a project using the CLI flags, use this name.
+ * If the current path (cwd) is inside a git repository, use the repository name
+ * If the current path (cwd) is not inside a git repository, use the directory name
+ */
+const getProjectName = async ({
+    currentPath = defaultCurrentPath,
+    cliParams = defaultCliParams,
+} = defaultParams) => {
+    if (cliParams.flags.project) {
+        return cliParams.flags.project;
+    }
+
+    // TODO: Detect other types of repository (mercurial, etc.)
+    const candidates = await Promise.all([
+        getProjectNameFromGitRepository(currentPath),
+        getProjectNameFromDirectory(currentPath),
+    ]);
+
+    return candidates.find(candidate => Boolean(candidate));
 };
 
 export default getProjectName;
+
+const getProjectNameFromDirectory = path => basename(path);
+
+const getFileNameWithoutExtension = name => {
+    const extension = extname(name);
+
+    return name.replace(extension, '');
+};
+
+const getProjectNameFromGitRepository = async (
+    currentPath = defaultCurrentPath
+) => {
+    const thisPath = path.isAbsolute(currentPath)
+        ? currentPath
+        : path.join(defaultCurrentPath, currentPath);
+
+    try {
+        const { stdout } = await execa(
+            'git',
+            ['config', '--get', 'remote.origin.url'],
+            {
+                cwd: thisPath,
+            }
+        );
+
+        const result = basename(stdout);
+        return getFileNameWithoutExtension(result);
+    } catch (e) {
+        return undefined;
+    }
+};

--- a/packages/cli/src/commands/get-project-name.js
+++ b/packages/cli/src/commands/get-project-name.js
@@ -1,40 +1,22 @@
 import { basename, extname } from 'path';
 import execa from 'execa';
-import path from 'path';
-import meow from 'meow';
-
-const defaultCliParams = meow({
-    flags: {
-        project: {
-            type: 'string',
-        },
-    },
-});
-
-const defaultCurrentPath = process.cwd();
-
-const defaultParams = {
-    currentPath: defaultCurrentPath,
-    cliParams: defaultCliParams,
-};
+import getProjectRoot from './get-project-root';
 
 /*
  * If user has specified a project using the CLI flags, use this name.
  * If the current path (cwd) is inside a git repository, use the repository name
  * If the current path (cwd) is not inside a git repository, use the directory name
  */
-const getProjectName = async ({
-    currentPath = defaultCurrentPath,
-    cliParams = defaultCliParams,
-} = defaultParams) => {
-    if (cliParams.flags.project) {
-        return cliParams.flags.project;
+const getProjectName = async (flags = {}) => {
+    if (flags.project) {
+        return flags.project;
     }
 
+    const projectRoot = getProjectRoot(flags);
     // TODO: Detect other types of repository (mercurial, etc.)
     const candidates = await Promise.all([
-        getProjectNameFromGitRepository(currentPath),
-        getProjectNameFromDirectory(currentPath),
+        getProjectNameFromGitRepository(projectRoot),
+        getProjectNameFromDirectory(projectRoot),
     ]);
 
     return candidates.find(candidate => Boolean(candidate));
@@ -50,19 +32,13 @@ const getFileNameWithoutExtension = name => {
     return name.replace(extension, '');
 };
 
-const getProjectNameFromGitRepository = async (
-    currentPath = defaultCurrentPath
-) => {
-    const thisPath = path.isAbsolute(currentPath)
-        ? currentPath
-        : path.join(defaultCurrentPath, currentPath);
-
+const getProjectNameFromGitRepository = async projectRoot => {
     try {
         const { stdout } = await execa(
             'git',
             ['config', '--get', 'remote.origin.url'],
             {
-                cwd: thisPath,
+                cwd: projectRoot,
             }
         );
 

--- a/packages/cli/src/commands/get-project-name.spec.js
+++ b/packages/cli/src/commands/get-project-name.spec.js
@@ -1,0 +1,28 @@
+import { tmpdir } from 'os';
+import getProjectName from './get-project-name';
+
+describe('getProjectName', () => {
+    it('Returns the name of the git repository if found', async () => {
+        const name = await getProjectName();
+        expect(name).toEqual('eydia');
+    });
+
+    it('Returns the name of the directory if no git repository is found', async () => {
+        const root = tmpdir();
+        const name = await getProjectName({
+            currentPath: root,
+        });
+        expect(name).toEqual('tmp');
+    });
+
+    it('Returns the name specified through flags', async () => {
+        const name = await getProjectName({
+            cliParams: {
+                flags: {
+                    project: 'test',
+                },
+            },
+        });
+        expect(name).toEqual('test');
+    });
+});

--- a/packages/cli/src/commands/get-project-name.spec.js
+++ b/packages/cli/src/commands/get-project-name.spec.js
@@ -10,18 +10,14 @@ describe('getProjectName', () => {
     it('Returns the name of the directory if no git repository is found', async () => {
         const root = tmpdir();
         const name = await getProjectName({
-            currentPath: root,
+            cwd: root,
         });
         expect(name).toEqual('tmp');
     });
 
     it('Returns the name specified through flags', async () => {
         const name = await getProjectName({
-            cliParams: {
-                flags: {
-                    project: 'test',
-                },
-            },
+            project: 'test',
         });
         expect(name).toEqual('test');
     });

--- a/packages/cli/src/commands/get-project-root.js
+++ b/packages/cli/src/commands/get-project-root.js
@@ -1,0 +1,11 @@
+const defaultCwd = process.cwd();
+
+const defaultParams = {
+    cwd: defaultCwd,
+};
+
+const getProjectRoot = ({ cwd = defaultCwd } = defaultParams) => {
+    return cwd;
+};
+
+export default getProjectRoot;

--- a/packages/cli/src/commands/init/gather-dependencies.js
+++ b/packages/cli/src/commands/init/gather-dependencies.js
@@ -1,7 +1,9 @@
 import { resolve } from 'path';
 import { readdirSync, statSync } from 'fs';
+import getProjectRoot from '../get-project-root';
 
-const gatherDependencies = projectRoot => {
+const gatherDependencies = flags => {
+    const projectRoot = getProjectRoot(flags);
     const packageFiles = getPackageFiles(projectRoot, true);
     const dependencies = gatherAllDependencies(packageFiles);
 

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -84,7 +84,7 @@ const initReducer = (state, action) => {
 };
 
 const handleWelcomeStep = async (dispatch, flags) => {
-    const projectName = getProjectName(flags);
+    const projectName = await getProjectName(flags);
 
     setTimeout(
         () => dispatch({ type: ACTION_SET_PROJECT_NAME, payload: projectName }),
@@ -93,7 +93,7 @@ const handleWelcomeStep = async (dispatch, flags) => {
 };
 
 const handleGatherDependenciesStep = async (dispatch, flags) => {
-    const dependencies = gatherDependencies(flags);
+    const dependencies = await gatherDependencies(flags);
     setTimeout(
         () => dispatch({ type: ACTION_UPDATE_PROJECT, payload: dependencies }),
         2000

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -7,10 +7,10 @@ import gatherDependencies from './gather-dependencies';
 import Loading from '../loading';
 import Success from './success';
 
-const Init = ({ onExit, projectRoot = process.cwd() }) => {
+const Init = ({ onExit, flags }) => {
     const [state, dispatch] = useReducer(initReducer, initialState);
 
-    useEffect(handleSteps(dispatch, state, onExit, projectRoot), [state]);
+    useEffect(handleSteps(dispatch, state, onExit, flags), [state]);
 
     if (state.step === STEP_WELCOME) {
         return <Loading>Initializing Eydia...</Loading>;
@@ -83,8 +83,8 @@ const initReducer = (state, action) => {
     }
 };
 
-const handleWelcomeStep = async (dispatch, projectRoot) => {
-    const projectName = getProjectName(projectRoot);
+const handleWelcomeStep = async (dispatch, flags) => {
+    const projectName = getProjectName(flags);
 
     setTimeout(
         () => dispatch({ type: ACTION_SET_PROJECT_NAME, payload: projectName }),
@@ -92,8 +92,8 @@ const handleWelcomeStep = async (dispatch, projectRoot) => {
     );
 };
 
-const handleGatherDependenciesStep = async (dispatch, projectRoot) => {
-    const dependencies = gatherDependencies(projectRoot);
+const handleGatherDependenciesStep = async (dispatch, flags) => {
+    const dependencies = gatherDependencies(flags);
     setTimeout(
         () => dispatch({ type: ACTION_UPDATE_PROJECT, payload: dependencies }),
         2000
@@ -112,14 +112,14 @@ const handleSteps = (
     dispatch,
     { step, projectName, dependencies },
     onExit,
-    projectRoot
+    flags
 ) => () => {
     if (step === STEP_WELCOME) {
-        handleWelcomeStep(dispatch, projectRoot);
+        handleWelcomeStep(dispatch, flags);
     }
 
     if (step === STEP_GATHERING_DEPENDENCIES) {
-        handleGatherDependenciesStep(dispatch, projectRoot);
+        handleGatherDependenciesStep(dispatch, flags);
     }
 
     if (step === STEP_UPDATING_PROJECT) {

--- a/packages/cli/src/commands/loading.js
+++ b/packages/cli/src/commands/loading.js
@@ -4,10 +4,12 @@ import Spinner from 'ink-spinner';
 
 const Loading = ({ children }) => (
     <Box>
-        <Color green>
-            <Spinner type="dots" />
-        </Color>
-        <Box paddingLeft={1}>{children}</Box>
+        <Box marginRight={1}>
+            <Color green>
+                <Spinner type="dots" />
+            </Color>
+        </Box>
+        {children}
     </Box>
 );
 

--- a/packages/cli/src/commands/todo/add/index.js
+++ b/packages/cli/src/commands/todo/add/index.js
@@ -7,7 +7,7 @@ import getProjectName from '../../get-project-name';
 import AskTitle from './ask-title';
 import Success from './success';
 
-const AddTodo = ({ title, onExit }) => {
+const AddTodo = ({ flags, title, onExit }) => {
     const [state, dispatch] = useReducer(todoReducer, getInitialState(title));
 
     const handleAddTodo = value =>
@@ -15,7 +15,7 @@ const AddTodo = ({ title, onExit }) => {
 
     // You can't pass an async function directly to useEffect
     useEffect(() => {
-        handleActions(state, dispatch, onExit);
+        handleActions(state, dispatch, onExit, flags);
     }, [state]);
 
     switch (state.step) {
@@ -75,10 +75,10 @@ const todoReducer = (state, action) => {
     return state;
 };
 
-const handleActions = async (state, dispatch, onExit) => {
+const handleActions = async (state, dispatch, onExit, flags) => {
     switch (state.step) {
         case STEP_SAVING_TODO: {
-            const projectName = await getProjectName();
+            const projectName = await getProjectName(flags);
             const link = await addTodo({ projectName, title: state.title });
             dispatch({
                 type: ACTION_SET_SUCCESS,

--- a/packages/cli/src/commands/todo/index.js
+++ b/packages/cli/src/commands/todo/index.js
@@ -5,17 +5,21 @@ import UnknownCommand from '../../unknown-command';
 import AddTodo from './add';
 import ListTodos from './list';
 
-const Todo = ({ match, onExit }) => (
+const Todo = ({ flags, match, onExit }) => (
     <Switch>
         <Route
             path={`${match.url}/add/:title?`}
             render={({ match }) => (
-                <AddTodo title={match.params.title} onExit={onExit} />
+                <AddTodo
+                    title={match.params.title}
+                    onExit={onExit}
+                    flags={flags}
+                />
             )}
         />
         <Route
             path={`${match.url}/list`}
-            render={() => <ListTodos onExit={onExit} />}
+            render={() => <ListTodos onExit={onExit} flags={flags} />}
         />
         <Redirect from={`${match.url}/`} to={`${match.url}/list`} exact />
         <Route component={UnknownCommand} />

--- a/packages/cli/src/commands/todo/list/index.js
+++ b/packages/cli/src/commands/todo/list/index.js
@@ -6,12 +6,12 @@ import Loading from '../../loading';
 import Error from '../../error';
 import List from './list';
 
-const ListTodos = ({ onExit }) => {
+const ListTodos = ({ flags, onExit }) => {
     const [state, dispatch] = useReducer(listTodosReducer, initialState);
 
     // You can't pass an async function directly to useEffect
     useEffect(() => {
-        handleListTodosSteps(state, dispatch, onExit);
+        handleListTodosSteps(state, dispatch, onExit, flags);
     }, [state]);
 
     switch (state.step) {
@@ -70,11 +70,11 @@ const listTodosReducer = (state, action) => {
     }
 };
 
-const handleListTodosSteps = async (state, dispatch, onExit) => {
+const handleListTodosSteps = async (state, dispatch, onExit, flags) => {
     switch (state.step) {
         case STEP_LOADING: {
             try {
-                const projectName = await getProjectName();
+                const projectName = await getProjectName(flags);
                 const todos = await listTodos(projectName);
                 dispatch({ type: ACTION_SET_TODOS, payload: todos });
             } catch (error) {

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -43,13 +43,21 @@ const Root = ({ onExit }) => {
                     <Route
                         path="/todo"
                         render={({ match }) => (
-                            <Todo match={match} onExit={onExit} />
+                            <Todo
+                                match={match}
+                                onExit={onExit}
+                                flags={cli.flags}
+                            />
                         )}
                     />
                     <Route
                         path="/init"
                         render={({ match }) => (
-                            <Init match={match} onExit={onExit} />
+                            <Init
+                                match={match}
+                                onExit={onExit}
+                                flags={cli.flags}
+                            />
                         )}
                     />
                     <Redirect from="/" to="/init" exact />


### PR DESCRIPTION
Follow #5 

The reasoning:

- If user has specified a project using the CLI flags, use it
- If the current path (cwd) is inside a git repository, use the repository name
- If the current path (cwd) is not inside a git repository, use the directory name