### PR TITLE
Add detailed help

### DIFF
--- a/packages/cli/src/command-help.js
+++ b/packages/cli/src/command-help.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { Box, Color, Text } from 'ink';
 
 const CommandHelp = ({ commands, children }) => (
-    <Box flexDirection="column" paddingTop={1}>
+    <Box flexDirection="column" marginTop={1}>
         <Box>
             {commands.map((command, index) => (
                 <Fragment key={command}>
@@ -11,8 +11,43 @@ const CommandHelp = ({ commands, children }) => (
                 </Fragment>
             ))}
         </Box>
-        <Text>{children}</Text>
+        <Box flexDirection="column" marginLeft={4}>
+            {children}
+        </Box>
     </Box>
 );
+
+const CommandHelpDescription = ({ children }) => <Text>{children}</Text>;
+CommandHelp.Description = CommandHelpDescription;
+
+const DefaultCommandDescriptionIntro =
+    'This command accepts the following flags:';
+
+const CommandFlags = ({ children, intro = DefaultCommandDescriptionIntro }) => (
+    <Box flexDirection="column" marginTop={1}>
+        <Text>{intro}</Text>
+        {children}
+    </Box>
+);
+CommandHelp.Flags = CommandFlags;
+
+const CommandFlag = ({ name, alias, multiple, children }) => (
+    <Box flexDirection="column" marginTop={1}>
+        <Box>
+            <Color grey>--{name}</Color>
+            {alias ? (
+                <>
+                    {' '}
+                    (<Color grey>-{alias}</Color>)
+                </>
+            ) : null}
+            {multiple ? <>. Can be specified multiple times.</> : null}
+        </Box>
+        <Box marginLeft={4}>
+            <Text>{children}</Text>
+        </Box>
+    </Box>
+);
+CommandHelp.Flag = CommandFlag;
 
 export default CommandHelp;

--- a/packages/cli/src/command-help.spec.js
+++ b/packages/cli/src/command-help.spec.js
@@ -11,7 +11,7 @@ describe('CommandHelp', () => {
 
         expect(lastFrame()).toEqual(`
 ${chalk.grey('eydia')}
-An help text`);
+    An help text`);
     });
 
     test('displays multipe commands correctly', async () => {
@@ -23,6 +23,6 @@ An help text`);
 
         expect(lastFrame()).toEqual(`
 ${chalk.grey('eydia')} or ${chalk.grey('eydia init')}
-An help text`);
+    An help text`);
     });
 });

--- a/packages/cli/src/commands/init/help.js
+++ b/packages/cli/src/commands/init/help.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import CommandHelp from '../../command-help';
+import DefaultFlags from '../../default-flags';
+
+const HelpInit = ({ showFlags }) => (
+    <>
+        <CommandHelp commands={['eydia', 'eydia init']}>
+            <CommandHelp.Description>
+                Initialize eydia for the current project
+            </CommandHelp.Description>
+        </CommandHelp>
+        {showFlags ? (
+            <CommandHelp.Flags>
+                <DefaultFlags />
+            </CommandHelp.Flags>
+        ) : null}
+    </>
+);
+
+export default HelpInit;

--- a/packages/cli/src/commands/todo/add/help.js
+++ b/packages/cli/src/commands/todo/add/help.js
@@ -1,11 +1,23 @@
 import React from 'react';
 import CommandHelp from '../../../command-help';
+import DefaultFlags from '../../../default-flags';
 
-const TodoAddHelp = () => (
+const TodoAddHelp = ({ showFlags }) => (
     <CommandHelp
         commands={['eydia todo add', 'eydia todo add "My todo title"']}
     >
-        Add a todo to the current project
+        <CommandHelp.Description>
+            Add a todo to the current project
+        </CommandHelp.Description>
+        {showFlags ? (
+            <CommandHelp.Flags>
+                <CommandHelp.Flag name="open" alias="o">
+                    Open the new todo edition page in the default browser
+                    immediately.
+                </CommandHelp.Flag>
+                <DefaultFlags />
+            </CommandHelp.Flags>
+        ) : null}
     </CommandHelp>
 );
 

--- a/packages/cli/src/commands/todo/help.js
+++ b/packages/cli/src/commands/todo/help.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import TodoListHelp from './list/help';
 import TodoAddHelp from './add/help';
+import CommandHelp from '../../command-help';
+import DefaultFlags from '../../default-flags';
 
-const TodoHelp = () => (
+const TodoHelp = ({ showDefaultFlags }) => (
     <>
         <TodoListHelp />
         <TodoAddHelp />
+        {showDefaultFlags ? (
+            <CommandHelp.Flags intro="All commands accept the following flags:">
+                <DefaultFlags />
+            </CommandHelp.Flags>
+        ) : null}
     </>
 );
 

--- a/packages/cli/src/commands/todo/index.js
+++ b/packages/cli/src/commands/todo/index.js
@@ -5,9 +5,16 @@ import UnknownCommand from '../../unknown-command';
 import AddTodo from './add';
 import ListTodos from './list';
 import Help from './help';
+import TodoAddHelp from './add/help';
+import TodoListHelp from './list/help';
+import HelpHowTo from '../../help-how-to';
 
 const Todo = ({ flags, match, onExit }) => (
     <Switch>
+        <Route
+            path={`${match.url}/add/help`}
+            render={() => <TodoAddHelp showFlags />}
+        />
         <Route
             path={`${match.url}/add/:title?`}
             render={({ match }) => (
@@ -19,6 +26,10 @@ const Todo = ({ flags, match, onExit }) => (
             )}
         />
         <Route
+            path={`${match.url}/list/help`}
+            render={() => <TodoListHelp showFlags />}
+        />
+        <Route
             path={`${match.url}/list`}
             render={() => <ListTodos onExit={onExit} flags={flags} />}
         />
@@ -26,13 +37,21 @@ const Todo = ({ flags, match, onExit }) => (
         <Route
             path={`${match.url}/help`}
             render={() => (
-                <UnknownCommand command="todo">
-                    <Help />
-                </UnknownCommand>
+                <>
+                    <Help showDefaultFlags />
+                    <HelpHowTo />
+                </>
             )}
         />
         // No match
-        <Redirect to={`${match.url}/help`} />
+        <Route
+            render={() => (
+                <UnknownCommand>
+                    <Help />
+                    <HelpHowTo />
+                </UnknownCommand>
+            )}
+        />
     </Switch>
 );
 

--- a/packages/cli/src/commands/todo/index.js
+++ b/packages/cli/src/commands/todo/index.js
@@ -8,11 +8,16 @@ import Help from './help';
 import TodoAddHelp from './add/help';
 import TodoListHelp from './list/help';
 import HelpHowTo from '../../help-how-to';
+import { HELP_ROUTE } from '../../constants';
 
 const Todo = ({ flags, match, onExit }) => (
     <Switch>
+        {/*
+            Using the HELP_ROUTE allows us to accept commands such as `eydia add help`
+            which will add a todo with title `help`
+        */}
         <Route
-            path={`${match.url}/add/help`}
+            path={`${match.url}/add/${HELP_ROUTE}`}
             render={() => <TodoAddHelp showFlags />}
         />
         <Route
@@ -26,7 +31,7 @@ const Todo = ({ flags, match, onExit }) => (
             )}
         />
         <Route
-            path={`${match.url}/list/help`}
+            path={`${match.url}/list/${HELP_ROUTE}`}
             render={() => <TodoListHelp showFlags />}
         />
         <Route
@@ -35,7 +40,7 @@ const Todo = ({ flags, match, onExit }) => (
         />
         <Redirect from={`${match.url}/`} to={`${match.url}/list`} exact />
         <Route
-            path={`${match.url}/help`}
+            path={`${match.url}/${HELP_ROUTE}`}
             render={() => (
                 <>
                     <Help showDefaultFlags />

--- a/packages/cli/src/commands/todo/list/help.js
+++ b/packages/cli/src/commands/todo/list/help.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import CommandHelp from '../../../command-help';
+import DefaultFlags from '../../../default-flags';
 
-const TodoListHelp = () => (
+const TodoListHelp = ({ showFlags = false }) => (
     <CommandHelp commands={['eydia todo', 'eydia todo list']}>
-        Show all the todos for the current project
+        <CommandHelp.Description>
+            Show all the todos for the current project
+        </CommandHelp.Description>
+        {showFlags ? (
+            <CommandHelp.Flags>
+                <DefaultFlags />
+            </CommandHelp.Flags>
+        ) : null}
     </CommandHelp>
 );
 

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -1,0 +1,1 @@
+export const HELP_ROUTE = '___help___';

--- a/packages/cli/src/default-flags.js
+++ b/packages/cli/src/default-flags.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import CommandHelp from './command-help';
+
+const DefaultFlags = () => (
+    <>
+        <CommandHelp.Flag name="cwd">
+            Sets the directory into which to execute the command. Default is the
+            current one.
+        </CommandHelp.Flag>
+        <CommandHelp.Flag name="project">
+            Sets the project name. Default is the current gir repository if
+            found or the current directory name.
+        </CommandHelp.Flag>
+    </>
+);
+
+export default DefaultFlags;

--- a/packages/cli/src/default-flags.js
+++ b/packages/cli/src/default-flags.js
@@ -4,8 +4,7 @@ import CommandHelp from './command-help';
 const DefaultFlags = () => (
     <>
         <CommandHelp.Flag name="cwd">
-            Sets the directory into which to execute the command. Default is the
-            current one.
+            Sets the working directory. Default is the current one.
         </CommandHelp.Flag>
         <CommandHelp.Flag name="project">
             Sets the project name. Default is the current git repository if

--- a/packages/cli/src/default-flags.js
+++ b/packages/cli/src/default-flags.js
@@ -8,7 +8,7 @@ const DefaultFlags = () => (
             current one.
         </CommandHelp.Flag>
         <CommandHelp.Flag name="project">
-            Sets the project name. Default is the current gir repository if
+            Sets the project name. Default is the current git repository if
             found or the current directory name.
         </CommandHelp.Flag>
     </>

--- a/packages/cli/src/help-how-to.js
+++ b/packages/cli/src/help-how-to.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box, Color } from 'ink';
+
+const HelpHowTo = () => (
+    <Box flexDirection="column" marginTop={1}>
+        <Box>Get help for a specific command by running:</Box>
+        <Color grey>eydia help [command]</Color>
+        <Box marginTop={1}>For example:</Box>
+        <Color grey>eydia help todo add</Color>
+    </Box>
+);
+
+export default HelpHowTo;

--- a/packages/cli/src/help.js
+++ b/packages/cli/src/help.js
@@ -6,6 +6,7 @@ import CommandHelp from './command-help';
 import DefaultFlags from './default-flags';
 import HelpHowTo from './help-how-to';
 import { HELP_ROUTE } from './constants';
+import HelpInit from './commands/init/help';
 
 const Help = ({ match }) => {
     if (match.params.command) {
@@ -20,11 +21,7 @@ const Help = ({ match }) => {
 
     return (
         <>
-            <CommandHelp commands={['eydia', 'eydia init']}>
-                <CommandHelp.Description>
-                    Initialize eydia for the current project
-                </CommandHelp.Description>
-            </CommandHelp>
+            <HelpInit />
             <TodoHelp />
             <CommandHelp.Flags intro="All commands accept the following flags:">
                 <DefaultFlags />

--- a/packages/cli/src/help.js
+++ b/packages/cli/src/help.js
@@ -5,10 +5,17 @@ import TodoHelp from './commands/todo/help';
 import CommandHelp from './command-help';
 import DefaultFlags from './default-flags';
 import HelpHowTo from './help-how-to';
+import { HELP_ROUTE } from './constants';
 
 const Help = ({ match }) => {
     if (match.params.command) {
-        return <Redirect to={`/${match.params.command}/help`} />;
+        /*
+            Using the HELP_ROUTE allows us to accept commands such as `eydia add help`
+            which will add a todo with title `help`
+
+            All sub commands help routes should use this constant for their path
+        */
+        return <Redirect to={`/${match.params.command}/${HELP_ROUTE}`} />;
     }
 
     return (

--- a/packages/cli/src/help.js
+++ b/packages/cli/src/help.js
@@ -1,14 +1,30 @@
 import React from 'react';
+import { Redirect } from 'react-router';
+
 import TodoHelp from './commands/todo/help';
 import CommandHelp from './command-help';
+import DefaultFlags from './default-flags';
+import HelpHowTo from './help-how-to';
 
-const Help = () => (
-    <>
-        <CommandHelp commands={['eydia', 'eydia init']}>
-            Initialize eydia for the current project
-        </CommandHelp>
-        <TodoHelp />
-    </>
-);
+const Help = ({ match }) => {
+    if (match.params.command) {
+        return <Redirect to={`/${match.params.command}/help`} />;
+    }
+
+    return (
+        <>
+            <CommandHelp commands={['eydia', 'eydia init']}>
+                <CommandHelp.Description>
+                    Initialize eydia for the current project
+                </CommandHelp.Description>
+            </CommandHelp>
+            <TodoHelp />
+            <CommandHelp.Flags intro="All commands accept the following flags:">
+                <DefaultFlags />
+            </CommandHelp.Flags>
+            <HelpHowTo />
+        </>
+    );
+};
 
 export default Help;

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -62,16 +62,18 @@ const Root = ({ onExit }) => {
                         )}
                     />
                     <Route
-                        path="/help"
+                        path="/help/:command*"
+                        render={({ match }) => <Help match={match} />}
+                    />
+                    <Redirect from="/" to="/init" exact />
+                    // No match
+                    <Route
                         render={() => (
                             <UnknownCommand>
                                 <Help />
                             </UnknownCommand>
                         )}
                     />
-                    <Redirect from="/" to="/init" exact />
-                    // No match
-                    <Redirect to="/help" />
                 </Switch>
             </Router>
         </>

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -6,9 +6,11 @@ import { Router, Route, Switch, Redirect } from 'react-router';
 import { createMemoryHistory } from 'history';
 
 import Init from './commands/init';
+import HelpInit from './commands/init/help';
 import Todo from './commands/todo';
 import UnknownCommand from './unknown-command';
 import Help from './help';
+import { HELP_ROUTE } from './constants';
 
 const cli = meow({
     flags: {
@@ -50,6 +52,10 @@ const Root = ({ onExit }) => {
                                 flags={cli.flags}
                             />
                         )}
+                    />
+                    <Route
+                        path={`/init/${HELP_ROUTE}`}
+                        render={() => <HelpInit showFlags />}
                     />
                     <Route
                         path="/init"


### PR DESCRIPTION
Add support for specific command help:

- `eydia help`
- `eydia help todo`
- `eydia help todo add`

- [x] Support for commands help
- [x] Add help for the `init` command
- [x] Find a way to avoid `/todo/add/help` route as it forbids adding an `help` todo (solution may be to have a very cryptic internal route for help such as `___help___`)
